### PR TITLE
学習データ管理で用いるDBのモデル・マイグレーション・シードを作成(#17)

### DIFF
--- a/src/app/MTag.php
+++ b/src/app/MTag.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class MTag extends Model
+{
+    protected $guarded = array('tag_id');
+
+    public static $rules = array(
+        'tag_name' => 'required'
+    );
+}

--- a/src/app/TStudyContent.php
+++ b/src/app/TStudyContent.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TStudyContent extends Model
+{
+    protected $guarded = array('study_id');
+
+    public static $rules = array(
+        'study_title' => 'required',
+        'interval_type' => 'required',
+        'study_times' => 'required|integer',
+        'user_id' => 'required'
+    );
+}

--- a/src/app/TStudyContentTag.php
+++ b/src/app/TStudyContentTag.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TStudyContentTag extends Model
+{
+    public static $rules = array(
+        'study_id' => 'required',
+        'tag_id' => 'required'
+    );
+}

--- a/src/database/migrations/2020_01_31_202856_create_t_study_contents_table.php
+++ b/src/database/migrations/2020_01_31_202856_create_t_study_contents_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTStudyContentsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('t_study_contents', function (Blueprint $table) {
+            // 項目定義
+            $table->bigIncrements('study_id');
+            $table->string('study_title');
+            $table->string('content')->nullable();
+            $table->string('interval_type');
+            $table->integer('study_times');
+            $table->unsignedBigInteger('user_id');
+            $table->timestamps();
+
+            // 外部キー設定
+            $table->foreign('user_id')->references('id')->on('users');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('t_study_contents');
+    }
+}

--- a/src/database/migrations/2020_01_31_204429_create_m_tags_table.php
+++ b/src/database/migrations/2020_01_31_204429_create_m_tags_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateMTagsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('m_tags', function (Blueprint $table) {
+            // 項目定義
+            $table->bigIncrements('tag_id');
+            $table->string('tag_name');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('m_tags');
+    }
+}

--- a/src/database/migrations/2020_01_31_205445_create_t_study_content_tags_table.php
+++ b/src/database/migrations/2020_01_31_205445_create_t_study_content_tags_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTStudyContentTagsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('t_study_content_tags', function (Blueprint $table) {
+            // 項目定義
+            $table->unsignedBigInteger('study_id');
+            $table->unsignedBigInteger('tag_id');
+            $table->timestamps();
+
+            // 主キー設定
+            $table->primary(['study_id', 'tag_id']);
+
+            // 外部キー設定
+            $table->foreign('study_id')->references('study_id')->on('t_study_contents');
+            $table->foreign('tag_id')->references('tag_id')->on('m_tags');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('t_study_content_tags');
+    }
+}

--- a/src/database/seeds/DatabaseSeeder.php
+++ b/src/database/seeds/DatabaseSeeder.php
@@ -11,6 +11,9 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        // $this->call(UsersTableSeeder::class);
+        $this->call(UsersTableSeeder::class);
+        $this->call(TStudyContentsTableSeeder::class);
+        $this->call(MTagsTableSeeder::class);
+        $this->call(TStudyContentTagsTableSeeder::class);
     }
 }

--- a/src/database/seeds/MTagsTableSeeder.php
+++ b/src/database/seeds/MTagsTableSeeder.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Seeder;
+use App\MTag;
+
+class MTagsTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $param = [
+            'tag_name' => 'Vue.js'
+        ];
+        $tagData = new MTag;
+        $tagData->fill($param)->save();
+
+        $param = [
+            'tag_name' => 'Laravel'
+        ];
+        $tagData = new MTag;
+        $tagData->fill($param)->save();
+    }
+}

--- a/src/database/seeds/TStudyContentTagsTableSeeder.php
+++ b/src/database/seeds/TStudyContentTagsTableSeeder.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Seeder;
+use App\TStudyContentTag;
+
+class TStudyContentTagsTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $param = [
+            'study_id' => 1,
+            'tag_id' => 2
+        ];
+        $studyContentTagData = new TStudyContentTag;
+        $studyContentTagData->fill($param)->save();
+
+        $param = [
+            'study_id' => 2,
+            'tag_id' => 1
+        ];
+        $studyContentTagData = new TStudyContentTag;
+        $studyContentTagData->fill($param)->save();
+    }
+}

--- a/src/database/seeds/TStudyContentsTableSeeder.php
+++ b/src/database/seeds/TStudyContentsTableSeeder.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Seeder;
+use App\TStudyContent;
+
+class TStudyContentsTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $param = [
+            'study_title' => 'テストタイトル1',
+            'content' => 'テスト内容1',
+            'interval_type' => 'A',
+            'study_times' => 1,
+            'user_id' => 2
+        ];
+        $studyData = new TStudyContent;
+        $studyData->fill($param)->save();
+
+        $param = [
+            'study_title' => 'テストタイトル2',
+            'content' => 'テスト内容2',
+            'interval_type' => 'B',
+            'study_times' => 2,
+            'user_id' => 1
+        ];
+        $studyData = new TStudyContent;
+        $studyData->fill($param)->save();
+    }
+}

--- a/src/database/seeds/UsersTableSeeder.php
+++ b/src/database/seeds/UsersTableSeeder.php
@@ -15,7 +15,7 @@ class UsersTableSeeder extends Seeder
         $param = [
             'name' => 'nakajima',
             'email' => 'nakajima@nakajima.jp',
-            'password' => 'test_nakajima'
+            'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi'
         ];
         $userData = new User;
         $userData->fill($param)->save();
@@ -23,7 +23,7 @@ class UsersTableSeeder extends Seeder
         $param = [
             'name' => 'nakamura',
             'email' => 'nakamura@nakamura.jp',
-            'password' => 'test_nakamura'
+            'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi'
         ];
         $userData = new User;
         $userData->fill($param)->save();

--- a/src/database/seeds/UsersTableSeeder.php
+++ b/src/database/seeds/UsersTableSeeder.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Seeder;
+use App\User;
+
+class UsersTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $param = [
+            'name' => 'nakajima',
+            'email' => 'nakajima@nakajima.jp',
+            'password' => 'test_nakajima'
+        ];
+        $restdata = new User;
+        $restdata->fill($param)->save();
+
+        $param = [
+            'name' => 'nakamura',
+            'email' => 'nakamura@nakamura.jp',
+            'password' => 'test_nakamura'
+        ];
+        $restdata = new User;
+        $restdata->fill($param)->save();
+    }
+}

--- a/src/database/seeds/UsersTableSeeder.php
+++ b/src/database/seeds/UsersTableSeeder.php
@@ -17,15 +17,15 @@ class UsersTableSeeder extends Seeder
             'email' => 'nakajima@nakajima.jp',
             'password' => 'test_nakajima'
         ];
-        $restdata = new User;
-        $restdata->fill($param)->save();
+        $userData = new User;
+        $userData->fill($param)->save();
 
         $param = [
             'name' => 'nakamura',
             'email' => 'nakamura@nakamura.jp',
             'password' => 'test_nakamura'
         ];
-        $restdata = new User;
-        $restdata->fill($param)->save();
+        $userData = new User;
+        $userData->fill($param)->save();
     }
 }


### PR DESCRIPTION
# マイグレーション(テーブル作成)実行コマンド
- 初回実行時
docker-compose exec app php artisan migrate
- 2回目以降(既存DBをドロップ→テーブル作成)
docker-compose exec app php artisan migrate:fresh

# シード(レコード作成)作成コマンド
docker-compose exec app php artisan db:seed
# 参考
- テーブル定義閲覧のmysqlコマンド
SHOW CREATE TABLE users;
- モデルのバリデーションについて
https://qiita.com/fagai/items/9904409d3703ef6f79a2